### PR TITLE
Add checkbox to toggle skipping of 1st CSV line (header)

### DIFF
--- a/SL/IM.pm
+++ b/SL/IM.pm
@@ -1812,7 +1812,8 @@ sub prepare_import_data {
               VALUES ($reportid, ?, ?)|;
     my $rth = $dbh->prepare($query) || $form->dberror($query);
 
-    my $i = 0;
+    my $rowcount = 0;
+    my $i = $form->{skipheader} ? 1 : 0;
     my $j = 0;
 
     my @d = split /\n/, $form->{data};
@@ -1825,7 +1826,6 @@ sub prepare_import_data {
         @dl = &dataline($form);
 
         if ($#dl) {
-            $i++;
             for ( keys %{ $form->{ $form->{type} } } ) {
                 if ( defined $form->{ $form->{type} }->{$_}{ndx} ) {
 
@@ -1838,8 +1838,10 @@ sub prepare_import_data {
                     }
                 }
             }
+	    $i++;
+	    $rowcount++;
         }
-        $form->{rowcount} = $i;
+        $form->{rowcount} = $rowcount;
 
     }
     $dbh->disconnect;

--- a/bin/mozilla/im.pl
+++ b/bin/mozilla/im.pl
@@ -334,6 +334,10 @@ sub import {
 		<td align=left><input name=tabdelimited type=checkbox class=checkbox></td>
 	      </tr>
 	      <tr>
+		<th align=right colspan=2>| . $locale->text('Skip first line (header)') . qq|</th>
+		<td align=left><input name=skipheader type=checkbox class=checkbox checked></td>
+	      </tr>
+	      <tr>
 		<th align=right colspan=2>| . $locale->text('Handle quoted strings') . qq|</th>
 		<td align=left><input name=stringsquoted type=checkbox class=checkbox checked></td>
 	      </tr>


### PR DESCRIPTION
@tapwag correctly noted that the 1st line of new Domus imports is skipped. This is because the prior implementation of generic import *always* skipped the 1st line of CSV files.

This PR:
- adds a checkbox to toggle skipping of the 1st line
- *enables* the checkbox by default to **keep current behavior**
- this means for every Domus import you’d need to actively *disable* the checkbox
- merges into `devtest` like #4 

<img width="415" height="296" alt="Screenshot_20251218_160741" src="https://github.com/user-attachments/assets/b03a36f8-27ab-4f5a-b8a6-9cf1ced4a2a4" />
