### PR TITLE
Fix skipping of CSV header

### DIFF
--- a/SL/IM.pm
+++ b/SL/IM.pm
@@ -1812,9 +1812,7 @@ sub prepare_import_data {
               VALUES ($reportid, ?, ?)|;
     my $rth = $dbh->prepare($query) || $form->dberror($query);
 
-    my $rowcount = 0;
-    my $i = $form->{skipheader} ? 1 : 0;
-    my $j = 0;
+    my $i = 0;
 
     my @d = split /\n/, $form->{data};
     shift @d if !$form->{mapfile};
@@ -1826,6 +1824,7 @@ sub prepare_import_data {
         @dl = &dataline($form);
 
         if ($#dl) {
+            $i++;
             for ( keys %{ $form->{ $form->{type} } } ) {
                 if ( defined $form->{ $form->{type} }->{$_}{ndx} ) {
 
@@ -1838,10 +1837,8 @@ sub prepare_import_data {
                     }
                 }
             }
-	    $i++;
-	    $rowcount++;
         }
-        $form->{rowcount} = $rowcount;
+        $form->{rowcount} = $i;
 
     }
     $dbh->disconnect;

--- a/bin/mozilla/im.pl
+++ b/bin/mozilla/im.pl
@@ -334,10 +334,6 @@ sub import {
 		<td align=left><input name=tabdelimited type=checkbox class=checkbox></td>
 	      </tr>
 	      <tr>
-		<th align=right colspan=2>| . $locale->text('Skip first line (header)') . qq|</th>
-		<td align=left><input name=skipheader type=checkbox class=checkbox checked></td>
-	      </tr>
-	      <tr>
 		<th align=right colspan=2>| . $locale->text('Handle quoted strings') . qq|</th>
 		<td align=left><input name=stringsquoted type=checkbox class=checkbox checked></td>
 	      </tr>

--- a/bin/mozilla/im.pl
+++ b/bin/mozilla/im.pl
@@ -342,8 +342,8 @@ sub import {
 	</tr>
 	<tr>
 	  <th align=right>| . $locale->text('Mapfile') . qq|</th>
-	  <td><input name=mapfile type=radio class=radio value=1>&nbsp;| . $locale->text('Yes') . qq|&nbsp;
-	      <input name=mapfile type=radio class=radio value=0 checked>&nbsp;| . $locale->text('No') . qq|
+	  <td><label><input name=mapfile type=radio class=radio value=1        >&nbsp;| . $locale->text('Yes') . qq|</label>
+	      <label><input name=mapfile type=radio class=radio value=0 checked>&nbsp;| . $locale->text('No')  . qq|</label>
 	  </td>
 	</tr>
       </table>


### PR DESCRIPTION
I found the *Mapfile* option already implemented the skipping of the 1st CSV line :see_no_evil: and both options conflicted … So I removed the additional checkbox implemented in 9edf63d6a4d3e92925fe27ca71a118ee5e851ffc and made sure the logic does now work:

Example: input CSV with 10 raw lines

<img width="416" height="268" alt="image" src="https://github.com/user-attachments/assets/a56ff5da-f1e6-4ed1-8a16-e0e5b0633cbd" />

I also made the texts *Yes* and *No* clickable to select the radio buttons.

With *Mapfile Yes*: all 10 rows read
<img width="328" height="618" alt="image" src="https://github.com/user-attachments/assets/54d31481-55e9-47ed-8b33-4bc81f1dd16a" />

With *Mapfile No*: rows 2 to 10 (9 rows) read
<img width="322" height="587" alt="image" src="https://github.com/user-attachments/assets/2df0eefb-ccd9-45ea-a4c3-be9759344a5b" />
